### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,8 @@ services:
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
     tmpfs:
-      - /run
-      - /tmp
+      - /run:exec,rw
+      - /tmp:noexec
     depends_on:
       - readsb
 


### PR DESCRIPTION
- Add `exec,rw` to `/run` inside of `docker-compose.yml` to fix https://github.com/kx1t/docker-skysquitter/issues/14 and https://github.com/kx1t/docker-skysquitter/issues/15